### PR TITLE
expose parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,11 @@ var Parser = require('jade/lib/parser');
 var Compiler = require('./lib/compiler');
 
 /**
+ * Expose `Parser`.
+ */
+exports.Parser = Parser
+
+/**
  * Choose Generators handler
  * ES6 code may be an issue for legacy systems (old browsers, node < 0.11)
  * When the system does not support ES6 generator, the compiled code


### PR DESCRIPTION
Allow parser to be exposed so this can be extended. ie, https://github.com/jadejs/jade/issues/843
Jade also exports Lexer, but this is the change I need.